### PR TITLE
Ci updates

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -54,9 +54,9 @@ jobs:
           extra-args: |
             --from
             quay.io/centos-bootc/${{ matrix.os }}-bootc-dev:${{ matrix.tag }}
-          archs: amd64
+          archs: amd64, arm64
           context: ${{ env.dir }}
 
       - name: Push To quay.io
-        run: buildah push ${{ steps.build.outputs.image-with-tag }} docker://${{ steps.build.outputs.image-with-tag }}
+        run: buildah manifest push --all ${{ steps.build.outputs.image-with-tag }} docker://${{ steps.build.outputs.image-with-tag }}
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Login to quay.io
         run: buildah login --username ${{ secrets.QUAY_USER }} --password ${{ secrets.QUAY_PASSWORD }} quay.io
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name != 'pull_request' }}
 
       - name: Build
         id: build
@@ -56,4 +56,4 @@ jobs:
 
       - name: Push To quay.io
         run: buildah push ${{ steps.build.outputs.image-with-tag }} docker://${{ steps.build.outputs.image-with-tag }}
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+  schedule:
+    - cron: "50 */4 * * *"
+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
ci: Push on workflow_dispatch too

To allow automated rebuilds.

---

ci: Build on schedule too

Because the -dev image changes frequently too.

Closes: https://github.com/CentOS/centos-bootc-layered/issues/16

---

ci: Build for aarch64 too

Matching the dev images.

---

