### PR TITLE
ci: build stream9 qcow2 too

### DIFF
--- a/.github/workflows/build-and-push-cloud-qcow2.yml
+++ b/.github/workflows/build-and-push-cloud-qcow2.yml
@@ -22,8 +22,8 @@ jobs:
         include:
           - os: fedora
             tag: eln
-          #- os: centos
-          #  tag: stream9
+          - os: centos
+            tag: stream9
 
     env:
       dir: cloud


### PR DESCRIPTION
Now that https://github.com/osbuild/bootc-image-builder/pull/138 is fixed.